### PR TITLE
Add support for loader option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ module.exports = {
         options: {
           // All options are optional
           target: 'es2015', // default, or 'es20XX', 'esnext'
+          loader: 'tsx', // default value is current transpinling file ext
           jsxFactory: 'React.createElement',
           jsxFragment: 'React.Fragment',
           sourceMap: false // Enable sourcemap

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ module.exports = async function (source) {
 
   try {
     const ext = path.extname(this.resourcePath)
-    if (!exts.includes(ext)) {
+    if (!options.loader && !exts.includes(ext)) {
       return done(
         new Error(`[esbuild-loader] Unsupported file extension: ${ext}`)
       )
@@ -28,7 +28,7 @@ module.exports = async function (source) {
 
     const result = await service.transform(source, {
       target: options.target || 'es2015',
-      loader: ext.slice(1),
+      loader: options.loader || ext.slice(1),
       jsxFactory: options.jsxFactory,
       jsxFragment: options.jsxFragment,
       sourcemap: options.sourceMap

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -90,6 +90,27 @@ exports[`simple 2`] = `
 /************************************************************************/
 /******/ ({
 
+/***/ \\"./test/fixture/bar.js\\":
+/*!*****************************!*\\\\
+  !*** ./test/fixture/bar.js ***!
+  \\\\*****************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+\\"use strict\\";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, \\"default\\", function() { return Bar; });
+class Bar {
+  render() {
+    return React.createElement(\\"div\\", {
+      className: \\"hehe\\"
+    }, \\"hello there!!!\\");
+  }
+}
+
+
+/***/ }),
+
 /***/ \\"./test/fixture/foo.tsx\\":
 /*!******************************!*\\\\
   !*** ./test/fixture/foo.tsx ***!
@@ -121,8 +142,11 @@ class Foo {
 \\"use strict\\";
 __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _foo__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./foo */ \\"./test/fixture/foo.tsx\\");
+/* harmony import */ var _bar__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./bar */ \\"./test/fixture/bar.js\\");
+
 
 console.log(_foo__WEBPACK_IMPORTED_MODULE_0__[\\"default\\"]);
+console.log(_bar__WEBPACK_IMPORTED_MODULE_1__[\\"default\\"]);
 
 
 /***/ })

--- a/test/fixture/bar.js
+++ b/test/fixture/bar.js
@@ -1,0 +1,5 @@
+export default class Bar {
+  render() {
+    return <div className="hehe">hello there!!!</div>
+  }
+}

--- a/test/fixture/index.js
+++ b/test/fixture/index.js
@@ -1,3 +1,5 @@
 import Foo from './foo'
+import Bar from './bar'
 
 console.log(Foo)
+console.log(Bar)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -20,9 +20,16 @@ test('simple', async () => {
     module: {
       rules: [
         {
-          test: /\.[jt]sx?$/,
+          test: /\.tsx?$/,
           loader: esbuildLoader,
         },
+        {
+          test: /\.jsx?$/,
+          loader: esbuildLoader,
+          options: {
+            loader: 'tsx'
+          }
+        }
       ],
     },
     plugins: [new ESBuildPlugin()],


### PR DESCRIPTION
This PR adds support for a new option named `loader`. Current implementation gets the loader value from the current transpiling file extension but there are cases and project with `js` files containing `jsx` stuff like React components.

This option is optional and if it's not passed, everything will behave the same.

Thanks for the great work! Stay safe.