### PR TITLE
fix: Fix the problem that esbuild service cannot be detected due to childcompiler in webpack

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -13,6 +13,15 @@ class ESBuildPlugin {
       }
     }
 
+    compiler.hooks.thisCompilation.tap('esbuild', (compilation) => {
+      compilation.hooks.childCompiler.tap(
+        'esbuild',
+        (childCompiler, _compilerName, _compilerIndex) => {
+          childCompiler.$esbuildService = compiler.$esbuildService
+        }
+      )
+    })
+
     compiler.hooks.run.tapPromise('esbuild', async () => {
       await startService()
     })

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -16,7 +16,7 @@ class ESBuildPlugin {
     compiler.hooks.thisCompilation.tap('esbuild', (compilation) => {
       compilation.hooks.childCompiler.tap(
         'esbuild',
-        (childCompiler, _compilerName, _compilerIndex) => {
+        (childCompiler) => {
           childCompiler.$esbuildService = compiler.$esbuildService
         }
       )


### PR DESCRIPTION
fix: Fix the problem that esbuild service cannot be detected due to childcompiler in webpack

Among the common plugins in webpack, many plugins create child-compiler to build their own chunks.
However, the value of $esbuildservice is not correctly assigned, which causes errors in the
compilation of webpack on the child-compiler,For example, mini CSS extract plugin

Closes #16