### PR TITLE
Remove incorrect option passed to esbuild minifier

### DIFF
--- a/src/minify-plugin.js
+++ b/src/minify-plugin.js
@@ -95,7 +95,6 @@ class ESBuildMinifyPlugin {
         const result = await $esbuildService.transform(source, {
           ...this.options,
           sourcemap,
-          devtool,
           sourcefile: assetName,
         })
 


### PR DESCRIPTION
Newer esbuild versions validate the options passed to it's JS api, and this option was accidentally being passed. `devtool` is a webpack thing, not an `esbuild` thing, and we just use it to decide if we should ask `esbuild` for sourcemaps. Removing this option fixes warnings when using the `esbuild-loader` with `esbuild` 0.7.1.

Error was:

```
Error: Invalid option: "devtool"
    at checkForInvalidFlags (/Users/airhorns/Code/gadget/node_modules/esbuild/lib/main.js:226:13)
    at flagsForTransformOptions (/Users/airhorns/Code/gadget/node_modules/esbuild/lib/main.js:382:3)
    at Object.transform (/Users/airhorns/Code/gadget/node_modules/esbuild/lib/main.js:491:21)
    at /Users/airhorns/Code/gadget/node_modules/esbuild/lib/main.js:704:78
    at new Promise (<anonymous>)
    at Object.transform (/Users/airhorns/Code/gadget/node_modules/esbuild/lib/main.js:704:37)
    at ESBuildMinifyPlugin.processSource (/Users/airhorns/Code/gadget/node_modules/esbuild-loader/src/minify-plugin.js:86:42)
    at /Users/airhorns/Code/gadget/node_modules/esbuild-loader/src/minify-plugin.js:41:30
    at Array.map (<anonymous>)
    at /Users/airhorns/Code/gadget/node_modules/esbuild-loader/src/minify-plugin.js:39:38