### PR TITLE
Allow platform option for NodeJS transpilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ You might also like [maho](https://github.com/egoist/maho), a React framework po
 ## Install
 
 ```bash
-yarn add esbuild-loader --dev
+npm i -D esbuild esbuild-loader
+```
+
+or
+
+```bash
+yarn add --dev esbuild esbuild-loader
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -33,14 +33,15 @@
     ]
   },
   "dependencies": {
-    "esbuild": "^0.6.23",
     "loader-utils": "^2.0.0",
     "webpack-sources": "^1.4.3"
   },
   "peerDependencies": {
+    "esbuild": "^0.6.23",
     "webpack": "^4.40.0 || ^5.0.0"
   },
   "devDependencies": {
+    "esbuild": "^0.6.23",
     "@types/jest": "^26.0.9",
     "husky": "^4.2.5",
     "jest": "^26.0.1",

--- a/src/loader.js
+++ b/src/loader.js
@@ -19,6 +19,7 @@ async function ESBuildLoader(source) {
     const result = await service.transform(source, {
       target: options.target || 'es2015',
       loader: options.loader || 'js',
+      platform: options.platform || 'browser',
       jsxFactory: options.jsxFactory,
       jsxFragment: options.jsxFragment,
       sourcemap: this.sourceMap,


### PR DESCRIPTION
Simple change so esbuild-loader can also be used for NodeJS (but with browser as default target)