### PR TITLE
docs(README): target option in minify plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ In `webpack.config.js`:
 +   optimization: {
 +     minimize: true,
 +     minimizer: [
-+       new ESBuildMinifyPlugin()
++       new ESBuildMinifyPlugin({ target: 'es2015' })
 +     ],
 +   },
 


### PR DESCRIPTION
If you don't give the target to the minification plugin it will use nullish coalescing operator (`??`) to minify syntax which is not an `es2015` feature, resulting on crashes in older browsers.