### PR TITLE
feat: add Inject JSX helper before JSX and TSX files are processed by esbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,14 @@ Customize the JSX fragment function name to use.
 
 Read more about it in the [esbuild docs](https://esbuild.github.io/api/#jsx-fragment).
 
+#### jsxInject
+Type: `string`
+
+Default: ''
+
+Customize the JSX helper you want to use
+
+
 #### implementation
 Type: `{ transform: Function }`
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -13,6 +13,8 @@ type Except<ObjectType, Properties> = {
 type LoaderOptions = Except<TransformOptions, 'sourcemap' | 'sourcefile'> & {
 	/** Pass a custom esbuild implementation */
 	implementation?: Implementation;
+	/** Inject jSX helper before the file is processed by esbuild */
+	jsxInject?: string;
 };
 
 type MinifyPluginOptions = Except<TransformOptions, 'sourcefile'> & {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -33,6 +33,7 @@ async function ESBuildLoader(
 	const done = this.async();
 	const options: LoaderOptions = getOptions(this);
 	const {
+		jsxInject,
 		implementation,
 		...esbuildTransformOptions
 	} = options;
@@ -72,6 +73,10 @@ async function ESBuildLoader(
 		&& isTsExtensionPtrn.test(this.resourcePath)
 	) {
 		transformOptions.loader = 'ts';
+	}
+	// Inject JSX helper before JSX and TSX files are processed by esbuild
+	if (jsxInject && /\.(?:j|t)sx\b/.test(this.resourcePath)) {
+		source = jsxInject + ';' + source
 	}
 
 	try {


### PR DESCRIPTION
Add an entry that can customize the JSX helper, it is used in the same way as thevite, before the esbuild works, inject a custom JSX helper into all JSX/TSX files, and with the jsxFactory and jsxFragment can customize any desired parsing method

For example: [vue3 example](https://github.com/umbrella22/esbuild-loader-examples/tree/master/examples/vue3)

In addition to vue, in some custom jsx rendering functions, this is more convenient and understandable; 
For example: [tsx-dom](https://github.com/Lusito/tsx-dom)

