### PR TITLE
feat: support `legalComments: 'linked'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Type: `boolean`
 Minify JS using equivalent but shorter syntax.
 
 #### legalComments
-Type: `'none' | 'inline' | 'eof'`
+Type: `'none' | 'inline' | 'eof' | 'linked'`
 
 Default: `'inline'`
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -21,6 +21,8 @@ type MinifyPluginOptions = Except<TransformOptions, 'sourcefile'> & {
 	css?: boolean;
 	/** Pass a custom esbuild implementation */
 	implementation?: Implementation;
+	/** Partial support */
+	legalComments?: 'none' | 'inline' | 'eof' | 'linked';
 };
 
 export {

--- a/src/minify-plugin.ts
+++ b/src/minify-plugin.ts
@@ -124,7 +124,7 @@ class ESBuildMinifyPlugin {
 			...transformOptions
 		} = this.options;
 
-		// NOTE: esbuild fails with 'linked', so this code uses a workaround.
+		// esbuild Transform API doesn't support 'linked', so we fake it with 'eof'
 		// See https://github.com/privatenumber/esbuild-loader/issues/263
 		const isLegalCommentsLinked = transformOptions.legalComments === 'linked';
 		if (isLegalCommentsLinked) {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -217,6 +217,8 @@ const legalComments = {
 	'/src/index.js': `
 		//! legal comment
 		globalCall();
+		/*! legal comment 2 */
+		globalCall2();
 	`,
 };
 

--- a/test/minify.test.ts
+++ b/test/minify.test.ts
@@ -449,7 +449,7 @@ describe.each([
 		expect(file).toMatch('/*! For license information please see index.js.LEGAL.txt */');
 
 		const legalFile = built.fs.readFileSync('/dist/index.js.LEGAL.txt', 'utf8');
-		expect(legalFile).toMatch('//! legal comment');
+		expect(legalFile).toMatch('/*! legal comment 2 */\n//! legal comment');
 	});
 
 	test('minify with custom implementation', async () => {

--- a/test/minify.test.ts
+++ b/test/minify.test.ts
@@ -429,6 +429,29 @@ describe.each([
 		expect(file).not.toMatch('//! legal comment');
 	});
 
+	test('minify w/ legalComments - linked', async () => {
+		const built = await build(fixtures.legalComments, (config) => {
+			config.optimization = {
+				minimize: true,
+				minimizer: [
+					new ESBuildMinifyPlugin({
+						legalComments: 'linked',
+					}),
+				],
+			};
+		}, webpack);
+
+		expect(built.stats.hasWarnings()).toBe(false);
+		expect(built.stats.hasErrors()).toBe(false);
+
+		const file = built.fs.readFileSync('/dist/index.js', 'utf8');
+		expect(file).not.toMatch('//! legal comment');
+		expect(file).toMatch('/*! For license information please see index.js.LEGAL.txt */');
+
+		const legalFile = built.fs.readFileSync('/dist/index.js.LEGAL.txt', 'utf8');
+		expect(legalFile).toMatch('//! legal comment');
+	});
+
 	test('minify with custom implementation', async () => {
 		const builtUnminified = await build(fixtures.js);
 		const built = await build(fixtures.js, (config) => {


### PR DESCRIPTION
Fix #263

This pull request emulates the esbuild's behavior for `legalComments: 'linked'` since esbuild fails when passing the option as-is.

When passing `'linked'`, the option is internally converted to `'eof'`, and this change extracts legal comments from transformed code and then writes another file like `index.js.LEGAL.txt`.

If the code is wrong, feel free to let me know.