### PR TITLE
perf: only call `sourceAndMap()` when source maps are enabled

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -56,18 +56,20 @@ const transformAssets = async (
 		const assetIsCss = isCssFile.test(asset.name);
 		let source: string | Buffer | ArrayBuffer;
 		let map = null;
-
-		if (asset.source.sourceAndMap) {
-			const sourceAndMap = asset.source.sourceAndMap();
-			source = sourceAndMap.source;
-			map = sourceAndMap.map;
+		if (useSourceMap) {
+			if (asset.source.sourceAndMap) {
+				const sourceAndMap = asset.source.sourceAndMap();
+				source = sourceAndMap.source;
+				map = sourceAndMap.map;
+			} else {
+				source = asset.source.source();
+				if (asset.source.map) {
+					map = asset.source.map();
+				}
+			}
 		} else {
 			source = asset.source.source();
-			if (asset.source.map) {
-				map = asset.source.map();
-			}
 		}
-
 		const sourceAsString = source.toString();
 		const result = await transform(sourceAsString, {
 			...transformOptions,


### PR DESCRIPTION
**What**: This PR gets source from `asset.source.source()` instead of `asset.source.sourceAndMap()` if sourcemaps are disabled

**Why**: <!-- Why I did the thing I did --> `asset.source.sourceAndMap()` generates both `source` and `map`. When sourcemaps are disabled there's no need for `map`, so it's faster to use `asset.source.source()`