### PR TITLE
fix(plugin): only minimize when used as minimizer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
     - name: Test
       env:
-        NODE_OPTIONS: --openssl-legacy-provider 
+        NODE_OPTIONS: --openssl-legacy-provider
       run: pnpm test
 
     - name: Test Node.js v16


### PR DESCRIPTION
closes https://github.com/esbuild-kit/esbuild-loader/issues/331


## BREAKING CHANGE: No longer minifies when used in "plugin". Use in "minimizer" to enable minification by default.