### PR TITLE
remove `options` from options in `Define` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,10 +219,8 @@ In `webpack.config.js`:
 -             'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
 -         })
 +         new EsbuildPlugin({
-+             options: {
-+                 define: {
-+                     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
-+                 },
++             define: {
++                 'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
 +             },
 +         }),
       ]


### PR DESCRIPTION
Not like this feature is useful right now anyway, because of https://github.com/privatenumber/esbuild-loader/issues/344, but at least if that gets fixed the readme will be accurate.