### PR TITLE
fix: `tsconfig.json` edge-cases in dependencies

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -92,7 +92,7 @@ async function ESBuildLoader(
 					if (resourcePath.includes(`${path.sep}node_modules${path.sep}`)) {
 						this.emitWarning(tsconfigError);
 					} else {
-						this.emitError(tsconfigError);
+						return done(tsconfigError);
 					}
 				}
 			}

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -87,12 +87,13 @@ async function ESBuildLoader(
 				// Webpack shouldn't be loading the same path multiple times so doesn't need to be cached
 				tsconfig = getTsconfig(resourcePath, 'tsconfig.json', tsconfigCache);
 			} catch (error) {
-				if (resourcePath.split(path.sep).includes('node_modules')) {
-					this.emitWarning(
-						new Error(`[esbuild-loader] Error while discovering tsconfig.json in dependency: "${error?.toString()}"`),
-					);
-				} else {
-					throw error;
+				if (error instanceof Error) {
+					const tsconfigError = new Error(`[esbuild-loader] Error parsing tsconfig.json:\n${error.message}`);
+					if (resourcePath.includes(`${path.sep}node_modules${path.sep}`)) {
+						this.emitWarning(tsconfigError);
+					} else {
+						this.emitError(tsconfigError);
+					}
 				}
 			}
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -81,8 +81,21 @@ async function ESBuildLoader(
 		} else {
 			/* Detect tsconfig file */
 
-			// Webpack shouldn't be loading the same path multiple times so doesn't need to be cached
-			const tsconfig = getTsconfig(resourcePath, 'tsconfig.json', tsconfigCache);
+			let tsconfig;
+
+			try {
+				// Webpack shouldn't be loading the same path multiple times so doesn't need to be cached
+				tsconfig = getTsconfig(resourcePath, 'tsconfig.json', tsconfigCache);
+			} catch (error) {
+				if (resourcePath.split(path.sep).includes('node_modules')) {
+					this.emitWarning(
+						new Error(`[esbuild-loader] Error while discovering tsconfig.json in dependency: "${error?.toString()}"`),
+					);
+				} else {
+					throw error;
+				}
+			}
+
 			if (tsconfig) {
 				const fileMatcher = createFilesMatcher(tsconfig);
 				transformOptions.tsconfigRaw = fileMatcher(resourcePath) as TransformOptions['tsconfigRaw'];

--- a/tests/specs/tsconfig.ts
+++ b/tests/specs/tsconfig.ts
@@ -266,7 +266,7 @@ export default testSuite(({ describe }) => {
 			test('fails on invalid tsconfig.json', async () => {
 				await using fixture = await createFixture({
 					'tsconfig.json': tsconfigJson({
-						extends: 'something-imaginary',
+						extends: 'unresolvable-dep',
 					}),
 					src: {
 						'index.ts': `
@@ -315,18 +315,78 @@ export default testSuite(({ describe }) => {
 					reject: false,
 				});
 
-				expect(stdout).toMatch('Error parsing tsconfig.json:\nFile \'something-imaginary\' not found.');
+				expect(stdout).toMatch('Error parsing tsconfig.json:\nFile \'unresolvable-dep\' not found.');
 				expect(exitCode).toBe(1);
 			});
 
-			test('ignores invalid tsconfig.json in dependencies', async () => {
+			test('ignores invalid tsconfig.json in JS dependencies', async () => {
 				await using fixture = await createFixture({
 					'node_modules/fake-lib': {
 						'package.json': JSON.stringify({
 							name: 'fake-lib',
 						}),
 						'tsconfig.json': tsconfigJson({
-							extends: 'something-imaginary',
+							extends: 'unresolvable-dep',
+						}),
+						'index.js': 'export function testFn() { return "Hi!" }',
+					},
+					'src/index.ts': `
+					import { testFn } from "fake-lib";
+					testFn();
+					`,
+					'webpack.config.js': `
+					module.exports = {
+						mode: 'production',
+
+						optimization: {
+							minimize: false,
+						},
+
+						resolveLoader: {
+							alias: {
+								'esbuild-loader': ${JSON.stringify(esbuildLoader)},
+							},
+						},
+
+						resolve: {
+							extensions: ['.ts', '.js'],
+						},
+
+						module: {
+							rules: [
+								{
+									test: /.[tj]sx?$/,
+									loader: 'esbuild-loader',
+									options: {
+										target: 'es2015',
+									}
+								}
+							],
+						},
+
+						entry: {
+							index: './src/index.ts',
+						},
+					};
+					`,
+				});
+
+				const { stdout, exitCode } = await execa(webpackCli, {
+					cwd: fixture.path,
+				});
+
+				expect(stdout).not.toMatch('Error parsing tsconfig.json');
+				expect(exitCode).toBe(0);
+			});
+
+			test('warns on invalid tsconfig.json in TS dependencies', async () => {
+				await using fixture = await createFixture({
+					'node_modules/fake-lib': {
+						'package.json': JSON.stringify({
+							name: 'fake-lib',
+						}),
+						'tsconfig.json': tsconfigJson({
+							extends: 'unresolvable-dep',
 						}),
 						'index.ts': 'export function testFn(): string { return "Hi!" }',
 					},
@@ -373,10 +433,9 @@ export default testSuite(({ describe }) => {
 
 				const { stdout, exitCode } = await execa(webpackCli, {
 					cwd: fixture.path,
-					reject: false,
 				});
 
-				expect(stdout).toMatch('Error parsing tsconfig.json:\nFile \'something-imaginary\' not found.');
+				expect(stdout).toMatch('Error parsing tsconfig.json:\nFile \'unresolvable-dep\' not found.');
 
 				// Warning so doesn't fail
 				expect(exitCode).toBe(0);


### PR DESCRIPTION
Fixes #363 where esbuild-loader would resolve the tsconfig.json of external files under certain conditions, which most recently became a problem when one of these configs included an `extends` option that referenced a package not in the project's dependency tree, making it impossible to resolve.

The patch changes this behaviour and will attempt to resolve the tsconfig.json still, however when it encounters a problem, if the resource associated with the tsconfig is a third party dependency, it will suppress the error and log a warning instead of bailing.