### PR TITLE
docs: document `drop` transform option for stripping console/debugger in production builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,23 @@ Replace global identifiers with constant expressions (e.g., `'process.env.NODE_E
 
 Read more about it in the [esbuild docs](https://esbuild.github.io/api/#define).
 
+#### drop
+Type: `Array<'console' | 'debugger'>`
+
+Strip matching calls from the output. Useful for removing `console.*` from production builds.
+
+Read more about it in the [esbuild docs](https://esbuild.github.io/api/#drop).
+
+```diff
+ {
+     test: /\.[jt]sx?$/,
+     loader: 'esbuild-loader',
+     options: {
++        drop: ['console', 'debugger'],
+     },
+ }
+```
+
 #### implementation
 Type: `{ transform: Function }`
 
@@ -512,6 +529,19 @@ Type: `'none' | 'inline' | 'eof' | 'external'`
 Default: `'inline'`
 
 Read more about it in the [esbuild docs](https://esbuild.github.io/api/#legal-comments).
+
+#### drop
+Type: `Array<'console' | 'debugger'>`
+
+Strip matching calls from the output. Useful for removing `console.*` from production builds.
+
+Read more about it in the [esbuild docs](https://esbuild.github.io/api/#drop).
+
+```diff
+ new EsbuildPlugin({
++    drop: ['console', 'debugger'],
+ })
+```
 
 #### css
 Type: `boolean`


### PR DESCRIPTION
## PR Description

### What was the issue

esbuild 0.18 added a `drop` transform option (`Array<'console' | 'debugger'>`) that strips matching statements in a single pass. Since `EsbuildPlugin` and the loader both pass through all esbuild transform options untouched, this feature already works — but it was not mentioned anywhere in the README. Users coming from `babel-plugin-transform-remove-console` or Terser's `pure_funcs` had no way to discover that a zero-config native solution was available.

### Where was the issue

Purely in the README. No code changes were needed — the `LoaderOptions` and `EsbuildPluginOptions` types already extend esbuild's `TransformOptions`, so `drop` was already type-safe, and both `loader.ts` and `plugin.ts` spread all options into esbuild's `transform()` call.

### How it was fixed

Added `#### drop` documentation entries to both options sections in the README, each with type info, a short description, a link to the esbuild docs, and a code example:

- **Loader section** (line 448): placed after `#### define`, before `#### implementation`, with a Webpack rule config example
- **EsbuildPlugin section** (line 533): placed after `#### legalComments`, before `#### css`, with an `EsbuildPlugin` constructor example

Both entries follow the exact format of existing options in the README.

### Why this approach over alternatives

No code needed to be written — the feature already works through the existing passthrough architecture. The alternatives (adding a separate plugin, using Babel, wrapping every `console.log` with environment guards) are all heavier workarounds that defeat the purpose of using esbuild-loader for speed. Documenting the native option is the lightest, most correct fix.

### How to test locally

This is a documentation-only change — review the rendered markdown. The code examples shown are valid Webpack config. If you already use esbuild-loader, adding `drop: ['console', 'debugger']` to either the loader options or `new EsbuildPlugin(...)` will strip matching statements from the build output.

Closes #415